### PR TITLE
Update 01.31.2021_Search-DatastoreItem_Function.ps1

### DIFF
--- a/fercorrales.com_blog_code/January_2021/01.31.2021_Search-DatastoreItem_Function.ps1
+++ b/fercorrales.com_blog_code/January_2021/01.31.2021_Search-DatastoreItem_Function.ps1
@@ -79,7 +79,7 @@ List of files and folders displaying filename, datastore path and item type.
 
         #Variable required to count loop executions. Used to calculate progress in 'Write-Progress' below.
         $Counter = 0
-
+        $ResultSet = @()
     }
     
     PROCESS {
@@ -100,7 +100,7 @@ List of files and folders displaying filename, datastore path and item type.
 
             Set-Location $DS
 
-            Get-ChildItem -Filter $Expression -Recurse | Select-Object Name,FolderPath,ItemType | Format-Table -AutoSize
+            $ResultSet += Get-ChildItem -Filter $Expression -Recurse 
 
             Write-Verbose "Done with $DS"
 
@@ -113,6 +113,8 @@ List of files and folders displaying filename, datastore path and item type.
 
     } #PROCESS
 
-    END {}
+    END {
+        return $ResultSet
+    }
 
 } #Function


### PR DESCRIPTION
Return a full resultset with the child-item objects instead of the filtered value as text, so we can concatenate multiple runs, export to csv, or apply filters after execution